### PR TITLE
De-duplicate the species-discovery talks index landing

### DIFF
--- a/talks/species-discovery/index.html
+++ b/talks/species-discovery/index.html
@@ -94,24 +94,22 @@
         it transfers, <b>where to point it</b>, and the cases where it honestly fails.</p>
     </section>
 
-    <div class="series">The one-page brief</div>
+    <div class="series">Start here &middot; two ways into the same case</div>
 
     <a class="card" href="a-label-free-preflight/">
-      <div class="ch">research brief &middot; the whole result on one page</div>
+      <div class="ch">read &middot; one page</div>
       <h2>A label-free pre-flight for biodiversity discovery</h2>
-      <p>The condensed case: the closed-form embedding-geometry statistic, the verified numbers, the
-        integrity story, and an evidence table where every figure traces to a committed run.</p>
+      <p>The case in text, with an evidence table where every figure traces to a committed run. Skim it
+        in five minutes.</p>
       <div class="ev">+0.99 off-data identity transfer &middot; de-confounded 934-cell law &middot; the refuted bet, kept</div>
     </a>
 
-    <div class="series">Start here</div>
-
     <a class="card" href="two-shortfalls-one-preflight/">
-      <div class="ch">the big picture &middot; ~10 minutes</div>
+      <div class="ch">present &middot; ~10 minutes</div>
       <h2>Two Shortfalls, One Pre-flight</h2>
-      <p>The whole idea in one sitting: finding <i>what</i> exists and <i>where</i> it is as a single
-        value-of-information problem, the pilot arc, and how the results connect.</p>
-      <div class="ev">the VOI framing &middot; the integrity story &middot; how the three connect</div>
+      <p>The same case as slides: the value-of-information framing, the pilot arc, and how the three
+        deep-dive talks connect.</p>
+      <div class="ev">the VOI framing &middot; the pilot arc &middot; how the three connect</div>
     </a>
 
     <div class="series">The talks</div>


### PR DESCRIPTION
Collapses the competing "The one-page brief" and "Start here" sections on the species-discovery talks index into a single "Start here" group with two complementary entry points: read the brief (one page, evidence table) vs present the overview deck (~10 min).

Previously both sections were each billed as the complete overview ("the whole result" / "the whole idea") and both listed "the integrity story" — redundant once the brief was added. The deep-dive talks and deployment talk are unchanged; no cards removed.

---
*AI (Claude) supported my development of this PR.*
